### PR TITLE
add sexiness

### DIFF
--- a/site.config.js
+++ b/site.config.js
@@ -4,7 +4,7 @@ module.exports = {
 
   // if you want to restrict pages to a single notion workspace (optional)
   // (this should be a Notion ID; see the docs for how to extract this)
-  rootNotionSpaceId: null,
+  rootNotionSpaceId: '684fb1cf-ad2b-40c7-8e31-c099fa61e45f',
 
   // basic site info (required)
   name: 'Ubiquity DAO Hub',
@@ -29,7 +29,7 @@ module.exports = {
 
   // image CDN host to proxy all image requests through (optional)
   // NOTE: this requires you to set up an external image proxy
-  imageCDNHost: null,
+  imageCDNHost: 'https://ssfy.io',
 
   // Utteranc.es comments via GitHub issue comments (optional)
   utterancesGitHubRepo: null,
@@ -37,7 +37,7 @@ module.exports = {
   // whether or not to enable support for LQIP preview images (optional)
   // NOTE: this requires you to set up Google Firebase and add the environment
   // variables specified in .env.example
-  isPreviewImageSupportEnabled: false,
+  isPreviewImageSupportEnabled: true,
 
   // map of notion page IDs to URL paths (optional)
   // any pages defined here will override their default URL paths


### PR DESCRIPTION
for the sexy image loading technique, you'll need to add a local .env file which i'll send separately and you'll need to add these env vars to your vercel deployment as well.

the `rootNotionSpaceId` is a security thing making it so people who visit your site `/<random-notion-id>` won't resolve.

the `imageCDNHost` is an image cdn proxy that i run which you can leech off of. it makes pages with images load much faster.