### PR TITLE
Fix Notion sync regeneration

### DIFF
--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -31,8 +31,7 @@ export async function getSiteMap(): Promise<types.SiteMap> {
 }
 
 const getAllPages = pMemoize(getAllPagesImpl, {
-  cacheKey: (...args) => JSON.stringify(args),
-  cache: false
+  cacheKey: (...args) => JSON.stringify(args)
 })
 
 const getPage = async (pageId: string, ...args) => {

--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -8,6 +8,15 @@ import { getCanonicalPageId } from './get-canonical-page-id'
 import { notion } from './notion-api'
 
 const uuid = !!includeNotionIdInUrls
+const defaultPageCrawlConcurrency = 1
+
+const getPageCrawlConcurrency = () => {
+  const concurrency = Number(process.env.NOTION_PAGE_CRAWL_CONCURRENCY)
+
+  return Number.isInteger(concurrency) && concurrency > 0
+    ? concurrency
+    : defaultPageCrawlConcurrency
+}
 
 export async function getSiteMap(): Promise<types.SiteMap> {
   const partialSiteMap = await getAllPages(
@@ -22,7 +31,8 @@ export async function getSiteMap(): Promise<types.SiteMap> {
 }
 
 const getAllPages = pMemoize(getAllPagesImpl, {
-  cacheKey: (...args) => JSON.stringify(args)
+  cacheKey: (...args) => JSON.stringify(args),
+  cache: false
 })
 
 const getPage = async (pageId: string, ...args) => {
@@ -37,14 +47,21 @@ async function getAllPagesImpl(
   const pageMap = await getAllPagesInSpace(
     rootNotionPageId,
     rootNotionSpaceId,
-    getPage
+    getPage,
+    { concurrency: getPageCrawlConcurrency() }
   )
 
   const canonicalPageMap = Object.keys(pageMap).reduce(
     (map, pageId: string) => {
       const recordMap = pageMap[pageId]
       if (!recordMap) {
-        throw new Error(`Error loading page "${pageId}"`)
+        if (pageId === rootNotionPageId) {
+          throw new Error(`Error loading root page "${pageId}"`)
+        }
+
+        console.warn(`Skipping page "${pageId}" because Notion did not load it`)
+
+        return map
       }
 
       const block = recordMap.block[pageId]?.value

--- a/lib/normalize-notion-record-map.ts
+++ b/lib/normalize-notion-record-map.ts
@@ -1,0 +1,36 @@
+import { type ExtendedRecordMap } from 'notion-types'
+
+type RecordTable = Record<string, Record<string, unknown>>
+
+const hasNestedValue = (
+  value: unknown
+): value is { role?: unknown; value: Record<string, unknown> } =>
+  !!value &&
+  typeof value === 'object' &&
+  'value' in value &&
+  !!(value as { value?: unknown }).value &&
+  typeof (value as { value?: unknown }).value === 'object'
+
+export function normalizeNotionRecordMap(
+  recordMap: ExtendedRecordMap
+): ExtendedRecordMap {
+  for (const table of Object.values(recordMap) as RecordTable[]) {
+    if (!table || typeof table !== 'object' || Array.isArray(table)) {
+      continue
+    }
+
+    for (const [id, record] of Object.entries(table)) {
+      if (!hasNestedValue(record?.value)) {
+        continue
+      }
+
+      table[id] = {
+        ...record,
+        role: record.value.role ?? record.role,
+        value: record.value.value
+      }
+    }
+  }
+
+  return recordMap
+}

--- a/lib/notion-api.ts
+++ b/lib/notion-api.ts
@@ -1,5 +1,15 @@
 import { NotionAPI } from 'notion-client'
 
+import { normalizeNotionRecordMap } from './normalize-notion-record-map'
+
 export const notion = new NotionAPI({
   apiBaseUrl: process.env.NOTION_API_BASE_URL
 })
+
+const getPage = notion.getPage.bind(notion)
+
+notion.getPage = async (...args) => {
+  const recordMap = await getPage(...args)
+
+  return normalizeNotionRecordMap(recordMap)
+}

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -1,8 +1,7 @@
 import { type GetStaticProps } from 'next'
 
 import { NotionPage } from '@/components/NotionPage'
-import { domain, isDev } from '@/lib/config'
-import { getSiteMap } from '@/lib/get-site-map'
+import { domain } from '@/lib/config'
 import { resolveNotionPage } from '@/lib/resolve-notion-page'
 import { type PageProps, type Params } from '@/lib/types'
 
@@ -25,27 +24,10 @@ export const getStaticProps: GetStaticProps<PageProps, Params> = async (
 }
 
 export async function getStaticPaths() {
-  if (isDev) {
-    return {
-      paths: [],
-      fallback: true
-    }
-  }
-
-  const siteMap = await getSiteMap()
-
-  const staticPaths = {
-    paths: Object.keys(siteMap.canonicalPageMap).map((pageId) => ({
-      params: {
-        pageId
-      }
-    })),
-    // paths: [],
+  return {
+    paths: [],
     fallback: true
   }
-
-  console.log(staticPaths.paths)
-  return staticPaths
 }
 
 export default function NotionDomainDynamicPage(props) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,27 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/next",
-      "config": {
-        "nodeVersion": "18.x"
-      }
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "functions": {
+    "pages/index.tsx": {
+      "maxDuration": 60
+    },
+    "pages/[pageId].tsx": {
+      "maxDuration": 60
+    },
+    "pages/feed.tsx": {
+      "maxDuration": 60
+    },
+    "pages/sitemap.xml.tsx": {
+      "maxDuration": 60
+    },
+    "pages/api/*.ts": {
+      "maxDuration": 30
+    },
+    "pages/api/*.tsx": {
+      "maxDuration": 60
+    },
+    "pages/api/**/*.ts": {
+      "maxDuration": 30
     }
-  ]
+  }
 }


### PR DESCRIPTION
Closes #32.

## Summary
- Removes the legacy Vercel `builds` configuration and restores the native Next.js framework preset.
- Configures Vercel Function duration for ISR pages and API routes so background regeneration has enough time to finish.
- Normalizes nested Notion record-map entries returned by `notion-client` before rendering.
- Stops production builds from crawling every Notion page in `getStaticPaths`; dynamic pages now generate on demand.
- Makes sitemap crawling lower-concurrency and skips non-root pages that Notion fails to load, instead of failing the whole regeneration path.

## Why
The live site is serving stale output with `x-vercel-cache: STALE`. Local production builds also exposed two regeneration blockers:
- Notion records can arrive as nested `value.value` entries, which breaks `react-notion-x` rendering.
- Full-space Notion crawling can hit 429s and fail page-data collection.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check vercel.json lib/notion-api.ts lib/normalize-notion-record-map.ts lib/get-site-map.ts 'pages/[pageId].tsx'`
- `pnpm test:lint`
- `git diff --check`
- `pnpm build`

## Bounty
Preferred payout: 75 USD / USDT on Polygon PoS to `0xE7201960FEa5bFF7Ae4Fe3286093dCedabeDB003`.

/claim #32
