### PR TITLE
fix(actions): restore upstream sync auth

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:  # click the button on Github repo!
 
+permissions:
+  contents: write
+
 jobs:
   sync_latest_from_upstream:
     runs-on: ubuntu-latest
@@ -15,15 +18,16 @@ jobs:
     # REQUIRED step
     # Step 1: run a standard checkout action, provided by github
     - name: Checkout target repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
-        token: ${{ secrets.PAT_REPO_SYNC_DOCS_TOKEN }}
+        ref: ubiquity
+        persist-credentials: false
 
     # REQUIRED step
     # Step 2: run the sync action
     - name: Sync upstream changes
       id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.3
       with:
         target_sync_branch: ubiquity
         # REQUIRED 'target_repo_token' exactly like this!


### PR DESCRIPTION
## Summary

Fixes #30 by aligning the upstream sync workflow with the action's documented
token flow, so it can use the repository-provided `GITHUB_TOKEN` to update the
`ubiquity` branch instead of depending on a custom checkout token that can fail
with non-interactive HTTPS auth errors.

## Changes

- Grant the workflow explicit `contents: write` permission for branch updates.
- Update `actions/checkout` from v2 to v4.
- Check out the `ubiquity` branch explicitly.
- Avoid persisting checkout credentials before the sync action runs.
- Update `aormsby/Fork-Sync-With-Upstream-action` to v3.4.3.

## Verification

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/sync.yml')"`

## Notes

The issue shows the scheduled/manual sync failing with:

```text
fatal: could not read Username for 'https://github.com/': terminal prompts disabled
```

The sync action documentation recommends using `${{ secrets.GITHUB_TOKEN }}`
as `target_repo_token`, with checkout credentials not persisted. This patch
follows that pattern, checks out `ubiquity` explicitly to match the target
branch, and adds the explicit workflow permission needed for the token to push
back to the branch.
