### PR TITLE
Fix upstream sync workflow auth

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,9 +2,12 @@ name: 'Upstream Sync'
 
 on:
   schedule:
-    - cron:  '0 0 * * *' # scheduled at 00:00 every day
+    - cron: '0 0 * * *' # scheduled at 00:00 every day
 
-  workflow_dispatch:  # click the button on Github repo!
+  workflow_dispatch: # click the button on Github repo!
+
+permissions:
+  contents: write
 
 jobs:
   sync_latest_from_upstream:
@@ -12,33 +15,34 @@ jobs:
     name: Sync latest commits from upstream repo
 
     steps:
-    # REQUIRED step
-    # Step 1: run a standard checkout action, provided by github
-    - name: Checkout target repo
-      uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.PAT_REPO_SYNC_DOCS_TOKEN }}
+      # REQUIRED step
+      # Step 1: run a standard checkout action, provided by github
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          ref: ubiquity
+          persist-credentials: false
 
-    # REQUIRED step
-    # Step 2: run the sync action
-    - name: Sync upstream changes
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
-      with:
-        target_sync_branch: ubiquity
-        # REQUIRED 'target_repo_token' exactly like this!
-        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
-        upstream_sync_branch: main
-        upstream_sync_repo: transitive-bullshit/nextjs-notion-starter-kit
-      
-    # Step 3: Display a sample message based on the sync output var 'has_new_commits'
-    - name: New commits found
-      if: steps.sync.outputs.has_new_commits == 'true'
-      run: echo "New commits were found to sync."
-    
-    - name: No new commits
-      if: steps.sync.outputs.has_new_commits == 'false'
-      run: echo "There were no new commits."
-      
-    - name: Show value of 'has_new_commits'
-      run: echo ${{ steps.sync.outputs.has_new_commits }}
+      # REQUIRED step
+      # Step 2: run the sync action
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        with:
+          target_sync_branch: ubiquity
+          # REQUIRED 'target_repo_token' exactly like this!
+          target_repo_token: ${{ github.token }}
+          upstream_sync_branch: main
+          upstream_sync_repo: transitive-bullshit/nextjs-notion-starter-kit
+
+      # Step 3: Display a sample message based on the sync output var 'has_new_commits'
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}


### PR DESCRIPTION
﻿## Summary

Fixes the upstream sync workflow authentication path for #30.

## What changed

- Grants the workflow `contents: write` so the built-in GitHub token can push synced commits.
- Stops checkout from persisting a separate custom PAT credential.
- Checks out the `ubiquity` branch explicitly before the sync action runs.
- Updates `actions/checkout` to v4 and pins the sync action to v3.4.1.

## Why

The previous workflow depended on `PAT_REPO_SYNC_DOCS_TOKEN` during checkout and then passed `GITHUB_TOKEN` to the sync action without declaring write permissions. If the custom token is absent/invalid, the sync job can hit the reported non-interactive git auth failure.

## Validation

Verified the PR diff is limited to `.github/workflows/sync.yml`. I did not run the workflow from the fork because it would try to mutate the fork's `ubiquity` branch.
