### PR TITLE
fix: restore upstream sync authentication

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,9 +2,12 @@ name: 'Upstream Sync'
 
 on:
   schedule:
-    - cron:  '0 0 * * *' # scheduled at 00:00 every day
+    - cron: '0 0 * * *' # scheduled at 00:00 every day
 
   workflow_dispatch:  # click the button on Github repo!
+
+permissions:
+  contents: write
 
 jobs:
   sync_latest_from_upstream:
@@ -15,9 +18,10 @@ jobs:
     # REQUIRED step
     # Step 1: run a standard checkout action, provided by github
     - name: Checkout target repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
-        token: ${{ secrets.PAT_REPO_SYNC_DOCS_TOKEN }}
+        ref: ubiquity
+        persist-credentials: false
 
     # REQUIRED step
     # Step 2: run the sync action


### PR DESCRIPTION
Fixes #30

## Summary
- remove the custom checkout PAT secret from the upstream-sync workflow
- update checkout to `actions/checkout@v4` and disable persisted credentials before the sync action runs
- grant `contents: write` to the workflow `GITHUB_TOKEN` so the sync action can push to the target branch
- explicitly check out the `ubiquity` branch that the sync job updates

## Why
The upstream sync action documents that persisted checkout credentials can cause fetches from the upstream repository to authenticate incorrectly, resulting in `fatal: could not read Username for 'https://github.com/': terminal prompts disabled`. Using the default `GITHUB_TOKEN` for the sync action and disabling persisted checkout credentials keeps the target push token separate from upstream fetch credentials.

Reference: https://github-wiki-see.page/m/aormsby/Fork-Sync-With-Upstream-action/wiki/Configuration

## Validation
- inspected `.github/workflows/sync.yml` and changed only the sync workflow
- verified the workflow configuration against the upstream sync action documentation
- did not run the scheduled sync from this fork because the target repository workflow needs maintainer-owned permissions/secrets