### PR TITLE
Fix upstream sync workflow authentication

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -32,7 +32,7 @@ jobs:
       # Step 2: run the sync action
       - name: Sync upstream changes
         id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.3
         with:
           target_sync_branch: ubiquity
           # REQUIRED 'target_repo_token' exactly like this!

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,9 +2,17 @@ name: 'Upstream Sync'
 
 on:
   schedule:
-    - cron:  '0 0 * * *' # scheduled at 00:00 every day
+    - cron: '0 0 * * *' # scheduled at 00:00 every day
 
-  workflow_dispatch:  # click the button on Github repo!
+  workflow_dispatch: # click the button on Github repo!
+    inputs:
+      sync_test_mode:
+        description: 'Fork Sync Test Mode'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
 
 jobs:
   sync_latest_from_upstream:
@@ -12,33 +20,35 @@ jobs:
     name: Sync latest commits from upstream repo
 
     steps:
-    # REQUIRED step
-    # Step 1: run a standard checkout action, provided by github
-    - name: Checkout target repo
-      uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.PAT_REPO_SYNC_DOCS_TOKEN }}
+      # REQUIRED step
+      # Step 1: run a standard checkout action, provided by github
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          ref: ubiquity
+          persist-credentials: false
 
-    # REQUIRED step
-    # Step 2: run the sync action
-    - name: Sync upstream changes
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
-      with:
-        target_sync_branch: ubiquity
-        # REQUIRED 'target_repo_token' exactly like this!
-        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
-        upstream_sync_branch: main
-        upstream_sync_repo: transitive-bullshit/nextjs-notion-starter-kit
-      
-    # Step 3: Display a sample message based on the sync output var 'has_new_commits'
-    - name: New commits found
-      if: steps.sync.outputs.has_new_commits == 'true'
-      run: echo "New commits were found to sync."
-    
-    - name: No new commits
-      if: steps.sync.outputs.has_new_commits == 'false'
-      run: echo "There were no new commits."
-      
-    - name: Show value of 'has_new_commits'
-      run: echo ${{ steps.sync.outputs.has_new_commits }}
+      # REQUIRED step
+      # Step 2: run the sync action
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        with:
+          target_sync_branch: ubiquity
+          # REQUIRED 'target_repo_token' exactly like this!
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_sync_branch: main
+          upstream_sync_repo: transitive-bullshit/nextjs-notion-starter-kit
+          test_mode: ${{ github.event_name == 'workflow_dispatch' && inputs.sync_test_mode || false }}
+
+      # Step 3: Display a sample message based on the sync output var 'has_new_commits'
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}


### PR DESCRIPTION
Closes #30.\n\nThe failing run shows \atal: could not read Username for 'https://github.com/': terminal prompts disabled\ during the upstream sync workflow. The workflow currently checks out the repository with \${{ secrets.PAT_REPO_SYNC_DOCS_TOKEN }}\; if that custom secret is missing or invalid, checkout cannot authenticate.\n\nChanges:\n- Use \ctions/checkout@v4\ without the custom PAT secret.\n- Set \persist-credentials: false\, matching the upstream sync action's documented workflow.\n- Grant \contents: write\ so \${{ secrets.GITHUB_TOKEN }}\ can push sync commits.\n- Pin \ormsby/Fork-Sync-With-Upstream-action\ to \3.4.1\, matching the current documented release.\n- Add a manual \sync_test_mode\ input for safe workflow dispatch testing.\n\nValidation:\n- Confirmed the previous workflow fails a static check because it still depends on \PAT_REPO_SYNC_DOCS_TOKEN\.\n- Confirmed this workflow no longer references that PAT, includes \contents: write\, disables persisted checkout credentials, uses checkout v4, and passes \${{ secrets.GITHUB_TOKEN }}\ to \	arget_repo_token\.