### PR TITLE
feat: adopt supported Notion imports and blog metadata

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -39,7 +39,7 @@ import styles from './styles.module.css'
 // -----------------------------------------------------------------------------
 
 const Code = dynamic(() =>
-  import('react-notion-x/build/third-party/code').then(async (m) => {
+  import('react-notion-x/third-party/code').then(async (m) => {
     // add / remove any prism syntaxes here
     await Promise.allSettled([
       import('prismjs/components/prism-markup-templating.js'),
@@ -79,22 +79,20 @@ const Code = dynamic(() =>
 )
 
 const Collection = dynamic(() =>
-  import('react-notion-x/build/third-party/collection').then(
-    (m) => m.Collection
-  )
+  import('react-notion-x/third-party/collection').then((m) => m.Collection)
 )
 const Equation = dynamic(() =>
-  import('react-notion-x/build/third-party/equation').then((m) => m.Equation)
+  import('react-notion-x/third-party/equation').then((m) => m.Equation)
 )
 const Pdf = dynamic(
-  () => import('react-notion-x/build/third-party/pdf').then((m) => m.Pdf),
+  () => import('react-notion-x/third-party/pdf').then((m) => m.Pdf),
   {
     ssr: false
   }
 )
 const Modal = dynamic(
   () =>
-    import('react-notion-x/build/third-party/modal').then((m) => {
+    import('react-notion-x/third-party/modal').then((m) => {
       m.Modal.setAppElement('.notion-viewport')
       return m.Modal
     }),
@@ -283,6 +281,7 @@ export function NotionPage({
         description={socialDescription}
         image={socialImage}
         url={canonicalPageUrl}
+        isBlogPost={isBlogPost}
       />
 
       {isLiteMode && <BodyClassName className='notion-lite' />}

--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -2,18 +2,24 @@ import Head from 'next/head'
 
 import type * as types from '@/lib/types'
 import * as config from '@/lib/config'
+import {
+  getBlogPostStructuredData,
+  serializeStructuredData
+} from '@/lib/structured-data'
 
 export function PageHead({
   site,
   title,
   description,
   image,
-  url
+  url,
+  isBlogPost
 }: types.PageProps & {
   title?: string
   description?: string
   image?: string
   url?: string
+  isBlogPost?: boolean
 }) {
   const rssFeedUrl = `${config.host}/feed`
 
@@ -21,6 +27,15 @@ export function PageHead({
   description = description ?? site?.description
 
   const socialImageUrl = image // getSocialImageUrl(pageId) || image
+  const structuredData = getBlogPostStructuredData({
+    isBlogPost,
+    title,
+    description,
+    image: socialImageUrl,
+    url,
+    organizationName: config.author,
+    organizationUrl: site ? `https://${site.domain}` : undefined
+  })
 
   return (
     <Head>
@@ -98,6 +113,15 @@ export function PageHead({
       <meta property='og:title' content={title} />
       <meta name='twitter:title' content={title} />
       <title>{title}</title>
+
+      {structuredData && (
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: serializeStructuredData(structuredData)
+          }}
+        />
+      )}
     </Head>
   )
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,12 +7,16 @@
 import { parsePageId } from 'notion-utils'
 import { type PostHogConfig } from 'posthog-js'
 
-import { getEnv, getSiteConfig } from './get-config-value'
+import {
+  getEnv,
+  getRequiredSiteConfig,
+  getSiteConfig
+} from './get-config-value'
 import { type NavigationLink } from './site-config'
 import { type NavigationStyle, type Site } from './types'
 
 export const rootNotionPageId: string = parsePageId(
-  getSiteConfig('rootNotionPageId'),
+  getRequiredSiteConfig('rootNotionPageId'),
   { uuid: false }
 )
 
@@ -30,9 +34,9 @@ export const environment = process.env.NODE_ENV || 'development'
 export const isDev = environment === 'development'
 
 // general site config
-export const name: string = getSiteConfig('name')
-export const author: string = getSiteConfig('author')
-export const domain: string = getSiteConfig('domain')
+export const name: string = getRequiredSiteConfig('name')
+export const author: string = getRequiredSiteConfig('author')
+export const domain: string = getRequiredSiteConfig('domain')
 export const description: string = getSiteConfig('description', 'Notion Blog')
 export const language: string = getSiteConfig('language', 'en')
 
@@ -83,7 +87,7 @@ export const navigationStyle: NavigationStyle = getSiteConfig(
   'default'
 )
 
-export const navigationLinks: Array<NavigationLink | null> = getSiteConfig(
+export const navigationLinks: Array<NavigationLink> | null = getSiteConfig(
   'navigationLinks',
   null
 )

--- a/lib/get-config-value.ts
+++ b/lib/get-config-value.ts
@@ -6,11 +6,13 @@ if (!rawSiteConfig) {
 }
 
 // allow environment variables to override site.config.ts
-let siteConfigOverrides: SiteConfig
+let siteConfigOverrides: Partial<SiteConfig> | undefined
 
 try {
   if (process.env.NEXT_PUBLIC_SITE_CONFIG) {
-    siteConfigOverrides = JSON.parse(process.env.NEXT_PUBLIC_SITE_CONFIG)
+    siteConfigOverrides = JSON.parse(
+      process.env.NEXT_PUBLIC_SITE_CONFIG
+    ) as Partial<SiteConfig>
   }
 } catch (err) {
   console.error('Invalid config "NEXT_PUBLIC_SITE_CONFIG" failed to parse')
@@ -22,25 +24,41 @@ const siteConfig: SiteConfig = {
   ...siteConfigOverrides
 }
 
-export function getSiteConfig<T>(key: string, defaultValue?: T): T {
+export function getSiteConfig<K extends keyof SiteConfig>(
+  key: K
+): SiteConfig[K] | undefined
+export function getSiteConfig<K extends keyof SiteConfig, T>(
+  key: K,
+  defaultValue: T
+): Exclude<SiteConfig[K], undefined> | T
+export function getSiteConfig<K extends keyof SiteConfig, T>(
+  key: K,
+  defaultValue?: T
+) {
   const value = siteConfig[key]
 
   if (value !== undefined) {
     return value
   }
 
-  if (defaultValue !== undefined) {
-    return defaultValue
+  return defaultValue
+}
+
+export function getRequiredSiteConfig<K extends keyof SiteConfig>(
+  key: K
+): Exclude<SiteConfig[K], undefined> {
+  const value = siteConfig[key]
+
+  if (value !== undefined) {
+    return value as Exclude<SiteConfig[K], undefined>
   }
 
   throw new Error(`Config error: missing required site config value "${key}"`)
 }
 
-export function getEnv(
-  key: string,
-  defaultValue?: string,
-  env = process.env
-): string {
+export function getEnv(key: string, defaultValue?: undefined): string
+export function getEnv<T>(key: string, defaultValue: T): string | T
+export function getEnv<T>(key: string, defaultValue?: T, env = process.env) {
   const value = env[key]
 
   if (value !== undefined) {

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -2,7 +2,7 @@ import type * as types from './types'
 
 export interface SiteConfig {
   rootNotionPageId: string
-  rootNotionSpaceId?: string
+  rootNotionSpaceId?: string | null
 
   name: string
   domain: string

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,0 +1,50 @@
+interface BlogPostStructuredDataOptions {
+  isBlogPost?: boolean
+  title?: string
+  description?: string
+  image?: string
+  url?: string
+  organizationName: string
+  organizationUrl?: string
+}
+
+export function getBlogPostStructuredData({
+  isBlogPost,
+  title,
+  description,
+  image,
+  url,
+  organizationName,
+  organizationUrl
+}: BlogPostStructuredDataOptions) {
+  if (!isBlogPost || !title || !url) {
+    return null
+  }
+
+  const organization = {
+    '@type': 'Organization',
+    name: organizationName,
+    ...(organizationUrl ? { url: organizationUrl } : {})
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    '@id': `${url}#blog-posting`,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': url
+    },
+    url,
+    headline: title,
+    name: title,
+    ...(description ? { description } : {}),
+    ...(image ? { image } : {}),
+    author: organization,
+    publisher: organization
+  }
+}
+
+export function serializeStructuredData(value: unknown): string {
+  return JSON.stringify(value).replaceAll('<', '\\u003c')
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,7 +31,7 @@ export interface Site {
   domain: string
 
   rootNotionPageId: string
-  rootNotionSpaceId: string
+  rootNotionSpaceId: string | null
 
   // settings
   html?: string

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "run-p test:*",
     "test:lint": "eslint .",
     "test:prettier": "prettier '**/*.{js,jsx,ts,tsx}' --check",
-    "test:unit": "node --test test/routing.test.ts"
+    "test:unit": "node --test test/*.test.ts"
   },
   "dependencies": {
     "@keyvhq/core": "^2.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import 'katex/dist/katex.min.css'
 // used for code syntax highlighting (optional)
 import 'prismjs/themes/prism-coy.css'
 // core styles shared by all of react-notion-x (required)
-import 'react-notion-x/src/styles.css'
+import 'react-notion-x/styles.css'
 // global styles shared across the entire site
 import 'styles/global.css'
 // this might be better for dark mode

--- a/test/structured-data.test.ts
+++ b/test/structured-data.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getBlogPostStructuredData,
+  serializeStructuredData
+} from '../lib/structured-data.ts'
+
+test('collection pages emit organization-authored BlogPosting data', () => {
+  const data = getBlogPostStructuredData({
+    isBlogPost: true,
+    title: 'Protocol update',
+    description: 'A Ubiquity protocol update.',
+    image: 'https://dao.ubq.fi/social.png',
+    url: 'https://dao.ubq.fi/protocol-update-page-id',
+    organizationName: 'Ubiquity DAO',
+    organizationUrl: 'https://dao.ubq.fi'
+  })
+
+  assert.deepEqual(data, {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    '@id': 'https://dao.ubq.fi/protocol-update-page-id#blog-posting',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': 'https://dao.ubq.fi/protocol-update-page-id'
+    },
+    url: 'https://dao.ubq.fi/protocol-update-page-id',
+    headline: 'Protocol update',
+    name: 'Protocol update',
+    description: 'A Ubiquity protocol update.',
+    image: 'https://dao.ubq.fi/social.png',
+    author: {
+      '@type': 'Organization',
+      name: 'Ubiquity DAO',
+      url: 'https://dao.ubq.fi'
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Ubiquity DAO',
+      url: 'https://dao.ubq.fi'
+    }
+  })
+})
+
+test('non-blog pages and pages without canonical URLs omit structured data', () => {
+  assert.equal(
+    getBlogPostStructuredData({
+      isBlogPost: false,
+      title: 'About',
+      url: 'https://dao.ubq.fi/about',
+      organizationName: 'Ubiquity DAO'
+    }),
+    null
+  )
+
+  assert.equal(
+    getBlogPostStructuredData({
+      isBlogPost: true,
+      title: 'Local draft',
+      organizationName: 'Ubiquity DAO'
+    }),
+    null
+  )
+})
+
+test('structured data serialization cannot close the script element', () => {
+  const payload = {
+    title: '</script><script>alert(1)</script>'
+  }
+  const serialized = serializeStructuredData(payload)
+
+  assert.doesNotMatch(serialized, /<\/script>/i)
+  assert.match(serialized, /\\u003c\/script>/)
+  assert.deepEqual(JSON.parse(serialized), payload)
+})

--- a/test/upstream-maintenance.test.ts
+++ b/test/upstream-maintenance.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const publicReactNotionSpecifiers = [
+  'react-notion-x/styles.css',
+  'react-notion-x/third-party/code',
+  'react-notion-x/third-party/collection',
+  'react-notion-x/third-party/equation',
+  'react-notion-x/third-party/modal',
+  'react-notion-x/third-party/pdf'
+]
+
+test('react-notion-x integrations use exported public paths', async () => {
+  const notionPageSource = await readFile(
+    new URL('../components/NotionPage.tsx', import.meta.url),
+    'utf8'
+  )
+  const appSource = await readFile(
+    new URL('../pages/_app.tsx', import.meta.url),
+    'utf8'
+  )
+  const source = `${notionPageSource}\n${appSource}`
+
+  assert.doesNotMatch(source, /react-notion-x\/(?:build|src)\//)
+
+  for (const specifier of publicReactNotionSpecifiers) {
+    assert.ok(source.includes(specifier))
+    assert.doesNotThrow(() => import.meta.resolve(specifier))
+  }
+})
+
+test('blog classification reaches the JSON-LD script renderer', async () => {
+  const notionPageSource = await readFile(
+    new URL('../components/NotionPage.tsx', import.meta.url),
+    'utf8'
+  )
+  const pageHeadSource = await readFile(
+    new URL('../components/PageHead.tsx', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(notionPageSource, /isBlogPost={isBlogPost}/)
+  assert.match(pageHeadSource, /type='application\/ld\+json'/)
+  assert.match(pageHeadSource, /serializeStructuredData\(structuredData\)/)
+})


### PR DESCRIPTION
## Summary

- switch `react-notion-x` integrations to its supported public exports
- add organization-authored `BlogPosting` JSON-LD for collection pages
- escape Notion-authored JSON-LD content before inserting it into a script element
- tighten required and optional site-config typing without restoring manual URL overrides
- expand the offline suite from 10 routing tests to 15 routing, metadata, and import-boundary tests

## Why

This selectively ports the low-risk maintenance work from the upstream starter kit while preserving Ubiquity's structural routing, bounded Notion crawl, feed loader, retry behavior, DAO branding, and Vercel controls.

Using package-internal `build/` and `src/` imports made future dependency upgrades fragile. Upstream's blog metadata was also adapted so Ubiquity DAO is represented as an organization and Notion-authored text cannot terminate the JSON-LD script element.

## Validation

- `corepack pnpm test` — 15 tests passed; lint and formatting passed
- `corepack pnpm exec tsc --noEmit --incremental false`
- `corepack pnpm build` — production build completed and generated all seven clean Notion routes, including `/ubiquityos-for-daos`
