### PR TITLE
fix(ci): restore upstream sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,4 +37,5 @@ jobs:
           test_mode: ${{ github.event_name == 'workflow_dispatch' && inputs.sync_test_mode || false }}
 
       - name: Report sync result
-        run: echo "Upstream changes found: ${{ steps.sync.outputs.has_new_commits }}"
+        run: |
+          echo "Upstream changes found: ${{ steps.sync.outputs.has_new_commits }}"


### PR DESCRIPTION
## Summary

- make the upstream-sync report command a YAML block scalar
- restore GitHub Actions parsing so scheduled and manual sync runs can create jobs

## Root cause

The shell command was written as a YAML plain scalar containing `: ` inside embedded shell quotes. YAML treats that colon-space as a mapping boundary, so GitHub rejected the workflow before job creation. Every push therefore produced an immediate zero-job failure under `.github/workflows/sync.yml`.

## Validation

- Ruby YAML parser accepts `.github/workflows/sync.yml`
- `git diff --check` passes
- CI `30247442830` passes
- safe manual dispatch `30247451852` passes with `sync_test_mode: true`; all upstream-action self-tests and the report step complete successfully
- branch push creates no zero-job sync failure
- Vercel preview deployment passes
